### PR TITLE
Fix(Task/Ext/Archive/ZipTask): Preseves directories' permissions in zip

### DIFF
--- a/src/Phing/Task/Ext/Archive/ZipTask.php
+++ b/src/Phing/Task/Ext/Archive/ZipTask.php
@@ -306,6 +306,9 @@ class ZipTask extends MatchingTask
                 if ($f->isDirectory()) {
                     if ($pathInZip != '.') {
                         $zip->addEmptyDir($pathInZip);
+                        $dirAttrName = $pathInZip . '/';
+                        $dirAttrs = (int) fileperms($f->getPath()) << 16;
+                        $zip->setExternalAttributesName($dirAttrName, \ZipArchive::OPSYS_UNIX, $dirAttrs);
                     }
                 } else {
                     $zip->addFile($f->getAbsolutePath(), $pathInZip);


### PR DESCRIPTION
Fix #1817 Stores directories's original permissions as `ZipArchive::OPSYS_UNIX` `ExternalAttribute`.

No related PHPUnit ZipDirPermissions test yet but it addresses the issue.